### PR TITLE
Add GHA for Windows

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,11 @@
 # use ci-master https://github.com/metanorma/metanorma-build-scripts
 name: ubuntu
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   test-linux:
@@ -20,11 +24,10 @@ jobs:
           architecture: 'x64'
       - name: Update gems
         run: |
-          gem install bundler -v "~> 2"
+          gem install bundler
           bundle install --jobs 4 --retry 3
       - name: Use Metanorma
         run: |
-          sudo apt-get install -y libxml2-dev libxslt1-dev libicu-dev zlib1g-dev
           curl -L https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | sudo bash
           sudo chown -R $USER:$(id -gn $USER) $HOME/.config
       - name: Install yq
@@ -38,7 +41,3 @@ jobs:
           source $HOME/.nvm/nvm.sh
           nvm use mn-node
           make clean all publish
-      - name: Deploy
-        if: github.ref == 'refs/heads/master'
-        run: |
-          bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/deploy-to-gh-pages.sh | bash"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,11 @@
 # use ci-master https://github.com/metanorma/metanorma-build-scripts
 name: windows
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   test-windows:
@@ -21,8 +25,9 @@ jobs:
       - name: Update gems
         shell: pwsh
         run: |
-          gem install bundler -v "~> 2"
+          gem install bundler
           bundle config --local path vendor/bundle
+          bundle update
           bundle install --jobs 4 --retry 3
       - name: Use Metanorma
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,37 @@
+# Auto-generated !!! Do not edit it manually
+# use ci-master https://github.com/metanorma/metanorma-build-scripts
+name: windows
+
+on: [push]
+
+jobs:
+  test-windows:
+    name: Test on Ruby ${{ matrix.ruby }} Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ruby: [ '2.6', '2.5', '2.4' ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          architecture: 'x64'
+      - name: Update gems
+        shell: pwsh
+        run: |
+          gem install bundler -v "~> 2"
+          bundle config --local path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Use Metanorma
+        shell: pwsh
+        run: |
+          cinst -y metanorma
+      - name: Install yq
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_windows_amd64.exe " -OutFile ".\yq.exe"
+      - name: Metanorma compile
+        run: |
+          make -f Makefile.win clean all SHELL=cmd

--- a/Makefile.win
+++ b/Makefile.win
@@ -3,21 +3,24 @@
 # Ensure the xml2rfc cache directory exists locally
 IGNORE := $(shell md $(USERPROFILE)\.cache\xml2rfc)
 
-SRC := core\standard\17-069.adoc
+SRC := $(subst /,\\,$(shell yq r metanorma.yml metanorma.source.files | cut -c 3-999))
+ifeq ($(SRC),ll)
+SRC := $(filter-out README.adoc, $(wildcard sources\*.adoc))
+endif
 
 FORMAT_MARKER := mn-output-
 FORMATS := $(shell grep "$(FORMAT_MARKER)" $(SRC) | cut -f 2 -d " " | tr "," "\\n" | sort | uniq | tr "\\n" " ")
 
-XML  := $(patsubst %.adoc,%.xml,$(SRC))
-XMLRFC3  := $(patsubst %.adoc,%.v3.xml,$(SRC))
-HTML := $(patsubst %.adoc,%.html,$(SRC))
-DOC  := $(patsubst %.adoc,%.doc,$(SRC))
-PDF  := $(patsubst %.adoc,%.pdf,$(SRC))
-TXT  := $(patsubst %.adoc,%.txt,$(SRC))
-NITS := $(patsubst %.adoc,%.nits,$(wildcard draft-*.adoc))
-WSD  := $(wildcard models\*.wsd)
-XMI	 := $(patsubst models\%,xmi\%,$(patsubst %.wsd,%.xmi,$(WSD)))
-PNG	 := $(patsubst models\%,images\%,$(patsubst %.wsd,%.png,$(WSD)))
+XML  := $(patsubst sources\%,documents\%,$(patsubst %.adoc,%.xml,$(SRC)))
+XMLRFC3  := $(patsubst %.xml,%.v3.xml,$(OUTPUT_XML))
+HTML := $(patsubst %.xml,%.html,$(OUTPUT_XML))
+DOC  := $(patsubst %.xml,%.doc,$(OUTPUT_XML))
+PDF  := $(patsubst %.xml,%.pdf,$(OUTPUT_XML))
+TXT  := $(patsubst %.xml,%.txt,$(OUTPUT_XML))
+NITS := $(patsubst %.adoc,%.nits,$(wildcard sources/draft-*.adoc))
+WSD  := $(wildcard sources\models\*.wsd)
+XMI	 := $(patsubst sources\models\%,sources\xmi\%,$(patsubst %.wsd,%.xmi,$(WSD)))
+PNG	 := $(patsubst sources\models\%,sources\images\%,$(patsubst %.wsd,%.png,$(WSD)))
 
 COMPILE_CMD_LOCAL := bundle exec metanorma
 COMPILE_CMD_DOCKER := docker run -v "$$(pwd)":/metanorma/ ribose/metanorma metanorma
@@ -38,13 +41,13 @@ all: $(OUT_FILES)
 
 images: $(PNG)
 
-images\%.png: models/%.wsd
-	plantuml -tpng -o ../images/ $<
+images\%.png: models\%.wsd
+	plantuml -tpng -o ..\images\ $<
 
 xmi: $(XMI)
 
 xmi\%.xmi: models\%.wsd
-	plantuml -xmi:star -o ../xmi/ $<
+	plantuml -xmi:star -o ..\xmi\ $<
 
 define FORMAT_TASKS
 OUT_FILES-$(FORMAT) := $($(shell echo $(FORMAT) | tr '[:lower:]' '[:upper:]'))

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 This work item belongs to OGC.
 
 image:https://github.com/metanorma/ogc-wfs/workflows/ubuntu/badge.svg["Build Status (Ubuntu)", link="https://github.com/metanorma/ogc-wfs/actions?workflow=ubuntu"]
+image:https://github.com/metanorma/ogc-wfs/workflows/windows/badge.svg["Build Status (Windows)", link="https://github.com/metanorma/ogc-wfs/actions?workflow=windows"]
 
 This document is available in its rendered forms here:
 


### PR DESCRIPTION
@CAMOBAP795 the Windows `Makefile.win` is not updated to reflect the new `Makefile`. Can you update the centralized `Makefile.win` and apply that? Thanks.

This reverts commit 7f3955520c5d88d78ce3328b549920efd87a75a7.